### PR TITLE
Remove the permissions dispatcher library.

### DIFF
--- a/networkmonitor/build.gradle
+++ b/networkmonitor/build.gradle
@@ -106,8 +106,6 @@ dependencies {
         exclude group: "log4j"
     }
     implementation 'commons-net:commons-net:3.6'
-    implementation 'com.github.hotchemi:permissionsdispatcher:4.1.0'
-    annotationProcessor 'com.github.hotchemi:permissionsdispatcher-processor:4.1.0'
 
     implementation 'net.sourceforge.streamsupport:streamsupport:1.7.0'
 }

--- a/networkmonitor/src/main/java/ca/rmen/android/networkmonitor/util/PermissionUtil.java
+++ b/networkmonitor/src/main/java/ca/rmen/android/networkmonitor/util/PermissionUtil.java
@@ -25,10 +25,12 @@ package ca.rmen.android.networkmonitor.util;
 
 import android.Manifest;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.AppOpsManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+
 import androidx.core.app.ActivityCompat;
 
 public class PermissionUtil {
@@ -55,6 +57,24 @@ public class PermissionUtil {
         int mode = appOps.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS,
                 android.os.Process.myUid(), context.getPackageName());
         return mode == AppOpsManager.MODE_ALLOWED;
+    }
+
+    public static boolean areAllGranted(int[] grantResults) {
+        for (int grantResult : grantResults) {
+            if (grantResult != PackageManager.PERMISSION_GRANTED) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean shouldShowRationale(Activity activity, String[] permissions) {
+        for (String permission : permissions) {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/networkmonitor/src/main/res/raw/licenses.xml
+++ b/networkmonitor/src/main/res/raw/licenses.xml
@@ -48,12 +48,6 @@ limitations under the License.
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>PermissionsDispatcher</name>
-        <url>https://github.com/hotchemi/PermissionsDispatcher</url>
-        <copyright>Copyright (c) Shintaro Katafuchi, Marcel Schnelle, Yoshinori Isogai</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
         <name>streamsupport</name>
         <url>https://github.com/streamsupport/streamsupport</url>
         <copyright>Copyright (c) Oracle</copyright>


### PR DESCRIPTION
We don't need an external library to manage permissions.